### PR TITLE
fix: make examples pass `gce_zone` values for read pool instance into module

### DIFF
--- a/examples/example_with_multiple_readpool/main.tf
+++ b/examples/example_with_multiple_readpool/main.tf
@@ -50,7 +50,7 @@ module "alloy-db" {
       node_count        = 1,
       database_flags    = {},
       availability_type = "ZONAL",
-      ZONE              = "us-central1-a",
+      gce_zone          = "us-central1-a",
       machine_cpu_count = 1
     },
     {
@@ -60,7 +60,7 @@ module "alloy-db" {
       node_count        = 1,
       database_flags    = {},
       availability_type = "ZONAL",
-      ZONE              = "us-central1-a",
+      gce_zone          = "us-central1-a",
       machine_cpu_count = 1
     }
   ]

--- a/examples/example_with_readpool_instances/main.tf
+++ b/examples/example_with_readpool_instances/main.tf
@@ -50,7 +50,7 @@ module "alloy-db" {
       node_count        = 1,
       database_flags    = {},
       availability_type = "ZONAL",
-      ZONE              = "us-central1-a",
+      gce_zone          = "us-central1-a",
       machine_cpu_count = 1
     }
   ]


### PR DESCRIPTION
Related to the fix in this PR https://github.com/GoogleCloudPlatform/terraform-google-alloy-db/pull/43 for this issue https://github.com/GoogleCloudPlatform/terraform-google-alloy-db/issues/42

After I submitted the previous fix I was trying to create zonal read pool instances and realised that these inputs for the module were misnamed. Sorry that I didn't include this in the previous PR!