### PR TITLE
fix: continuous_backup_config and automated_backup_policy issue for failover replica

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ Current version is 2.X. Upgrade guides:
 
 ## Usage
 
-- Usage of this module for creating a AlloyDB Cluster with a scheduled automated backup policy
+- Functional examples are included in the [examples](./examples/) directory. If you want to create a cluster with failover replica and manage lifecycle of primary and secondary instance clusters lifecycle using this module, follow example in [simple_example](./examples/simple_example/)
+- Basic usage of this module is as follows:
 
 ```hcl
 module "alloy-db" {
@@ -61,7 +62,7 @@ module "alloy-db" {
 }
 ```
 
-- Usage of this module for creating a AlloyDB Cluster with a primary instance
+- Usage of this module for creating a AlloyDB Cluster with a primary instance and a read replica instance
 
 ```hcl
 module "alloy-db" {
@@ -87,13 +88,20 @@ module "alloy-db" {
     database_flags    = {},
     display_name      = "alloydb-primary-instance"
   }
-  read_pool_instance = null
+
+  read_pool_instance = [
+    {
+      instance_id        = "cluster-1-rr-1"
+      display_name       = "cluster-1-rr-1"
+      require_connectors = false
+      ssl_mode           = "ALLOW_UNENCRYPTED_AND_ENCRYPTED"
+    }
+  ]
 
   depends_on = [google_compute_network.default, google_compute_global_address.private_ip_alloc, google_service_networking_connection.vpc_connection]
 }
 ```
-Functional examples are included in the
-[examples](./examples/) directory.
+
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Inputs
@@ -142,7 +150,7 @@ These sections describe requirements for using this module.
 The following dependencies must be available:
 
 - [Terraform][terraform] v1.3
-- [Terraform Provider for GCP][terraform-provider-gcp] plugin >= v4.77
+- [Terraform Provider for GCP][terraform-provider-gcp] plugin >= v5.13+
 
 ### Service Account
 
@@ -151,19 +159,12 @@ the resources of this module:
 
 - Cloud AlloyDB Admin: `roles/alloydb.admin`
 
-The [Project Factory module][project-factory-module] and the
-[IAM module][iam-module] may be used in combination to provision a
-service account with the necessary roles applied.
-
 ### APIs
 
 A project with the following APIs enabled must be used to host the
 resources of this module:
 
 -  `alloydb.googleapis.com`
-
-The [Project Factory module][project-factory-module] can be used to
-provision a project with the necessary APIs enabled.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -107,7 +107,8 @@ Functional examples are included in the
 | cluster\_id | The ID of the alloydb cluster | `string` | n/a | yes |
 | cluster\_initial\_user | Alloy DB Cluster Initial User Credentials | <pre>object({<br>    user     = optional(string),<br>    password = string<br>  })</pre> | `null` | no |
 | cluster\_labels | User-defined labels for the alloydb cluster | `map(string)` | `{}` | no |
-| cluster\_location | Location where AlloyDb cluster will be deployed. | `string` | n/a | yes |
+| cluster\_location | Location where AlloyDb cluster will be deployed | `string` | n/a | yes |
+| cluster\_type | The type of cluster. If not set, defaults to PRIMARY. Default value is PRIMARY. Possible values are: PRIMARY, SECONDARY | `string` | `"PRIMARY"` | no |
 | continuous\_backup\_enable | Whether continuous backup recovery is enabled. If not set, defaults to true | `bool` | `true` | no |
 | continuous\_backup\_encryption\_key\_name | The fully-qualified resource name of the KMS key. Cloud KMS key should be in same region as Cluster and has the following format: projects/[PROJECT]/locations/[REGION]/keyRings/[RING]/cryptoKeys/[KEY\_NAME] | `string` | `null` | no |
 | continuous\_backup\_recovery\_window\_days | The numbers of days that are eligible to restore from using PITR (point-in-time-recovery). Defaults to 14 days. The value must be between 1 and 35 | `number` | `14` | no |

--- a/examples/example_with_multiple_readpool/main.tf
+++ b/examples/example_with_multiple_readpool/main.tf
@@ -36,34 +36,34 @@ module "alloy-db" {
   automated_backup_policy = null
 
   primary_instance = {
-    instance_id       = "primary-instance-1",
-    instance_type     = "PRIMARY",
-    machine_cpu_count = 2,
-    database_flags    = {},
-    display_name      = "alloydb-primary-instance",
+    instance_id       = "primary-instance-1"
+    instance_type     = "PRIMARY"
+    machine_cpu_count = 2
+    database_flags    = {}
+    display_name      = "alloydb-primary-instance"
   }
 
 
   read_pool_instance = [
     {
-      instance_id       = "read-instance-1",
-      display_name      = "read-instance-1",
-      instance_type     = "READ_POOL",
-      node_count        = 1,
-      database_flags    = {},
-      availability_type = "ZONAL",
-      gce_zone          = "us-central1-a",
-      machine_cpu_count = 1,
+      instance_id       = "read-instance-1"
+      display_name      = "read-instance-1"
+      instance_type     = "READ_POOL"
+      node_count        = 1
+      database_flags    = {}
+      availability_type = "ZONAL"
+      gce_zone          = "us-central1-a"
+      machine_cpu_count = 2
     },
     {
-      instance_id       = "read-instance-2",
-      display_name      = "read-instance-2",
-      instance_type     = "READ_POOL",
-      node_count        = 1,
-      database_flags    = {},
-      availability_type = "ZONAL",
-      gce_zone          = "us-central1-a",
-      machine_cpu_count = 1,
+      instance_id       = "read-instance-2"
+      display_name      = "read-instance-2"
+      instance_type     = "READ_POOL"
+      node_count        = 1
+      database_flags    = {}
+      availability_type = "ZONAL"
+      gce_zone          = "us-central1-a"
+      machine_cpu_count = 2
     }
   ]
 

--- a/examples/example_with_primary_instance/main.tf
+++ b/examples/example_with_primary_instance/main.tf
@@ -55,7 +55,7 @@ module "alloy-db" {
     database_flags = {
       "google_columnar_engine.scan_mode" = 2
     }
-    display_name = "alloydb-primary-instance",
+    display_name = "alloydb-primary-instance"
   }
 
   read_pool_instance = null

--- a/examples/example_with_readpool_instances/main.tf
+++ b/examples/example_with_readpool_instances/main.tf
@@ -22,11 +22,10 @@ module "alloy-db" {
   source  = "GoogleCloudPlatform/alloy-db/google"
   version = "~> 2.0"
 
-  project_id           = var.project_id
-  cluster_id           = "alloydb-cluster-nrp"
-  cluster_location     = "us-central1"
-  cluster_labels       = {}
-  cluster_display_name = ""
+  project_id       = var.project_id
+  cluster_id       = "alloydb-cluster-nrp"
+  cluster_location = "us-central1"
+  cluster_labels   = {}
   cluster_initial_user = {
     user     = "alloydb-cluster-full",
     password = "alloydb-cluster-password"
@@ -36,24 +35,24 @@ module "alloy-db" {
   automated_backup_policy = null
 
   primary_instance = {
-    instance_id       = "primary-instance-1",
-    instance_type     = "PRIMARY",
-    machine_cpu_count = 2,
-    database_flags    = {},
-    display_name      = "alloydb-primary-instance",
+    instance_id       = "primary-instance-1"
+    instance_type     = "PRIMARY"
+    machine_cpu_count = 2
+    database_flags    = {}
+    display_name      = "alloydb-primary-instance"
   }
 
 
   read_pool_instance = [
     {
-      instance_id       = "read-instance-1",
-      display_name      = "read-instance-1",
-      instance_type     = "READ_POOL",
-      node_count        = 1,
-      database_flags    = {},
-      availability_type = "ZONAL",
-      gce_zone          = "us-central1-a",
-      machine_cpu_count = 1,
+      instance_id       = "read-instance-1"
+      display_name      = "read-instance-1"
+      instance_type     = "READ_POOL"
+      node_count        = 1
+      database_flags    = {}
+      availability_type = "ZONAL"
+      gce_zone          = "us-central1-a"
+      machine_cpu_count = 2
     }
   ]
 

--- a/examples/simple_example/README.md
+++ b/examples/simple_example/README.md
@@ -17,15 +17,81 @@ terraform apply
 terraform destroy
 ```
 
+## Failover to Instance 2
+
+Steps to promote `cluster 2` as primary and change `cluster 1` as failover replica
+
+1) remove  `primary_cluster_name` from `cluster 2` and Execute `terraform apply`
+
+```diff
+module "alloydb2" {
+  source  = "GoogleCloudPlatform/alloy-db/google"
+  version = "~> 2.0"
+
+  ## Comment this out in order to promote cluster as primary cluster
+-  primary_cluster_name = module.alloydb1.cluster_name
+```
+
+2) Remove cluster 1 by removing cluster 1 code and Execute `terraform apply`
+
+```diff
+- module "alloydb1" {
+-   source  = "GoogleCloudPlatform/alloy-db/google"
+-   version = "~> 2.0"
+-   cluster_id       = "cluster-1"
+-   cluster_location = var.region1
+-   project_id       = var.project_id
+-   network_self_link           = "projects/${var.project_id}/global/networks/${var.network_name}"
+-   cluster_encryption_key_name = google_kms_crypto_key.key_region1.id
+- ...
+- }
+- output "cluster_id" {
+-   description = "ID of the Alloy DB Cluster created"
+-   value       = module.alloydb1.cluster_id
+- }
+- output "primary_instance_id" {
+-   description = "ID of the primary instance created"
+-   value       = module.alloydb1.primary_instance_id
+- }
+- output "cluster_name" {
+-   description = "The name of the cluster resource"
+-   value       = module.alloydb1.cluster_name
+- }
+```
+
+3) Create cluster 1 as failover replica by adding cluster 1 code with following additional line and Execute `terraform apply`
+
+```diff
+module "alloydb1" {
+  source  = "GoogleCloudPlatform/alloy-db/google"
+  version = "~> 2.0"
+
++  primary_cluster_name = module.alloydb2.cluster_name
+
+  cluster_id       = "cluster-1"
+  cluster_location = var.region1
+  project_id       = var.project_id
+
+  network_self_link           = "projects/${var.project_id}/global/networks/${var.network_name}"
+  cluster_encryption_key_name = google_kms_crypto_key.key_region1.id
+...
+  depends_on = [
+-    module.alloydb1,
+    google_service_networking_connection.vpc_connection,
+    google_kms_crypto_key_iam_member.alloydb_sa_iam_secondary,
+  ]
+}
+```
+
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| network\_name | The ID of the network in which to provision resources. | `string` | `"simple"` | no |
+| network\_name | The ID of the network in which to provision resources. | `string` | `"simple-adb"` | no |
 | project\_id | The ID of the project in which to provision resources. | `string` | n/a | yes |
-| region | The region for primary cluster | `string` | `"us-central1"` | no |
-| secondary\_region | The region for cross region replica secondary cluster | `string` | `"us-east1"` | no |
+| region1 | The region for cluster 1 | `string` | `"us-central1"` | no |
+| region2 | The region for cluster 2 | `string` | `"us-east1"` | no |
 
 ## Outputs
 

--- a/examples/simple_example/cross_region_replica.tf
+++ b/examples/simple_example/cross_region_replica.tf
@@ -28,7 +28,7 @@ module "alloydb_east" {
   cluster_encryption_key_name = google_kms_crypto_key.key_region_east.id
 
   primary_instance = {
-    instance_id = "cluster-${var.region_east}-instance-1",
+    instance_id = "cluster-${var.region_east}-instance1",
 
     client_connection_config = {
       require_connectors = false

--- a/examples/simple_example/cross_region_replica.tf
+++ b/examples/simple_example/cross_region_replica.tf
@@ -14,21 +14,21 @@
  * limitations under the License.
  */
 
-module "alloydb2" {
+module "alloydb_east" {
   source  = "GoogleCloudPlatform/alloy-db/google"
   version = "~> 2.0"
 
-  primary_cluster_name = module.alloydb1.cluster_name ## Comment this line to promote this cluster as primary cluster
+  primary_cluster_name = module.alloydb_central.cluster_name ## Comment this line to promote this cluster as primary cluster
 
-  cluster_id       = "cluster-2"
-  cluster_location = var.region2
+  cluster_id       = "cluster-${var.region_east}"
+  cluster_location = var.region_east
   project_id       = var.project_id
 
   network_self_link           = "projects/${var.project_id}/global/networks/${var.network_name}"
-  cluster_encryption_key_name = google_kms_crypto_key.key_region2.id
+  cluster_encryption_key_name = google_kms_crypto_key.key_region_east.id
 
   primary_instance = {
-    instance_id = "cluster-2-instance-1",
+    instance_id = "cluster-${var.region_east}-instance-1",
 
     client_connection_config = {
       require_connectors = false
@@ -38,10 +38,10 @@ module "alloydb2" {
 
   continuous_backup_enable               = true
   continuous_backup_recovery_window_days = 10
-  continuous_backup_encryption_key_name  = google_kms_crypto_key.key_region2.id
+  continuous_backup_encryption_key_name  = google_kms_crypto_key.key_region_east.id
 
   automated_backup_policy = {
-    location      = var.region2
+    location      = var.region_east
     backup_window = "1800s"
     enabled       = true
     weekly_schedule = {
@@ -53,11 +53,11 @@ module "alloydb2" {
     labels = {
       test = "alloydb-cluster-with-prim"
     }
-    backup_encryption_key_name = google_kms_crypto_key.key_region2.id
+    backup_encryption_key_name = google_kms_crypto_key.key_region_east.id
   }
 
   depends_on = [
-    module.alloydb1,
+    module.alloydb_central,
     google_service_networking_connection.vpc_connection,
     google_kms_crypto_key_iam_member.alloydb_sa_iam_secondary,
   ]

--- a/examples/simple_example/kms.tf
+++ b/examples/simple_example/kms.tf
@@ -27,20 +27,20 @@ resource "random_string" "key_suffix" {
   upper   = false
 }
 
-resource "google_kms_key_ring" "keyring_region1" {
+resource "google_kms_key_ring" "keyring_region_central" {
   project  = var.project_id
-  name     = "keyring-${var.region1}-${random_string.key_suffix.result}"
-  location = var.region1
+  name     = "keyring-${var.region_central}-${random_string.key_suffix.result}"
+  location = var.region_central
 }
 
-resource "google_kms_crypto_key" "key_region1" {
-  name     = "key-${var.region1}-${random_string.key_suffix.result}"
-  key_ring = google_kms_key_ring.keyring_region1.id
+resource "google_kms_crypto_key" "key_region_central" {
+  name     = "key-${var.region_central}-${random_string.key_suffix.result}"
+  key_ring = google_kms_key_ring.keyring_region_central.id
 }
 
 
 resource "google_kms_crypto_key_iam_member" "alloydb_sa_iam" {
-  crypto_key_id = google_kms_crypto_key.key_region1.id
+  crypto_key_id = google_kms_crypto_key.key_region_central.id
   role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
   member        = "serviceAccount:${google_project_service_identity.alloydb_sa.email}"
 }
@@ -48,19 +48,19 @@ resource "google_kms_crypto_key_iam_member" "alloydb_sa_iam" {
 
 ## Cross Region Secondary Cluster Keys
 
-resource "google_kms_key_ring" "keyring_region2" {
+resource "google_kms_key_ring" "keyring_region_east" {
   project  = var.project_id
-  name     = "keyring-${var.region2}-${random_string.key_suffix.result}"
-  location = var.region2
+  name     = "keyring-${var.region_east}-${random_string.key_suffix.result}"
+  location = var.region_east
 }
 
-resource "google_kms_crypto_key" "key_region2" {
-  name     = "key-${var.region2}-${random_string.key_suffix.result}"
-  key_ring = google_kms_key_ring.keyring_region2.id
+resource "google_kms_crypto_key" "key_region_east" {
+  name     = "key-${var.region_east}-${random_string.key_suffix.result}"
+  key_ring = google_kms_key_ring.keyring_region_east.id
 }
 
 resource "google_kms_crypto_key_iam_member" "alloydb_sa_iam_secondary" {
-  crypto_key_id = google_kms_crypto_key.key_region2.id
+  crypto_key_id = google_kms_crypto_key.key_region_east.id
   role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
   member        = "serviceAccount:${google_project_service_identity.alloydb_sa.email}"
 }

--- a/examples/simple_example/main.tf
+++ b/examples/simple_example/main.tf
@@ -56,7 +56,6 @@ module "alloydb1" {
       display_name       = "cluster-1-rr-1"
       require_connectors = false
       ssl_mode           = "ALLOW_UNENCRYPTED_AND_ENCRYPTED"
-      # availability_type = "ZONAL"
     }
   ]
 

--- a/examples/simple_example/main.tf
+++ b/examples/simple_example/main.tf
@@ -14,19 +14,19 @@
  * limitations under the License.
  */
 
-module "alloydb1" {
+module "alloydb_central" {
   source  = "GoogleCloudPlatform/alloy-db/google"
   version = "~> 2.0"
 
-  cluster_id       = "cluster-1"
-  cluster_location = var.region1
+  cluster_id       = "cluster-${var.region_central}"
+  cluster_location = var.region_central
   project_id       = var.project_id
 
   network_self_link           = "projects/${var.project_id}/global/networks/${var.network_name}"
-  cluster_encryption_key_name = google_kms_crypto_key.key_region1.id
+  cluster_encryption_key_name = google_kms_crypto_key.key_region_central.id
 
   automated_backup_policy = {
-    location      = var.region1
+    location      = var.region_central
     backup_window = "1800s"
     enabled       = true
     weekly_schedule = {
@@ -38,22 +38,22 @@ module "alloydb1" {
     labels = {
       test = "alloydb-cluster-with-prim"
     }
-    backup_encryption_key_name = google_kms_crypto_key.key_region1.id
+    backup_encryption_key_name = google_kms_crypto_key.key_region_central.id
   }
 
   continuous_backup_recovery_window_days = 10
-  continuous_backup_encryption_key_name  = google_kms_crypto_key.key_region1.id
+  continuous_backup_encryption_key_name  = google_kms_crypto_key.key_region_central.id
 
   primary_instance = {
-    instance_id        = "cluster-1-instance-1",
+    instance_id        = "cluster-${var.region_central}-instance-1",
     require_connectors = false
     ssl_mode           = "ALLOW_UNENCRYPTED_AND_ENCRYPTED"
   }
 
   read_pool_instance = [
     {
-      instance_id        = "cluster-1-rr-1"
-      display_name       = "cluster-1-rr-1"
+      instance_id        = "cluster-${var.region_central}-rr-1"
+      display_name       = "cluster-${var.region_central}-rr-1"
       require_connectors = false
       ssl_mode           = "ALLOW_UNENCRYPTED_AND_ENCRYPTED"
     }

--- a/examples/simple_example/main.tf
+++ b/examples/simple_example/main.tf
@@ -45,15 +45,15 @@ module "alloydb_central" {
   continuous_backup_encryption_key_name  = google_kms_crypto_key.key_region_central.id
 
   primary_instance = {
-    instance_id        = "cluster-${var.region_central}-instance-1",
+    instance_id        = "cluster-${var.region_central}-instance1",
     require_connectors = false
     ssl_mode           = "ALLOW_UNENCRYPTED_AND_ENCRYPTED"
   }
 
   read_pool_instance = [
     {
-      instance_id        = "cluster-${var.region_central}-rr-1"
-      display_name       = "cluster-${var.region_central}-rr-1"
+      instance_id        = "cluster-${var.region_central}-r1"
+      display_name       = "cluster-${var.region_central}-r1"
       require_connectors = false
       ssl_mode           = "ALLOW_UNENCRYPTED_AND_ENCRYPTED"
     }

--- a/examples/simple_example/main.tf
+++ b/examples/simple_example/main.tf
@@ -14,40 +14,19 @@
  * limitations under the License.
  */
 
-resource "google_compute_network" "default" {
-  name    = var.network_name
-  project = var.project_id
-}
-
-
-resource "google_compute_global_address" "private_ip_alloc" {
-  project       = var.project_id
-  name          = "adb-v6"
-  address_type  = "INTERNAL"
-  purpose       = "VPC_PEERING"
-  prefix_length = 16
-  network       = google_compute_network.default.id
-}
-
-resource "google_service_networking_connection" "vpc_connection" {
-  network                 = google_compute_network.default.id
-  service                 = "servicenetworking.googleapis.com"
-  reserved_peering_ranges = [google_compute_global_address.private_ip_alloc.name]
-}
-
-module "alloy-db" {
+module "alloydb1" {
   source  = "GoogleCloudPlatform/alloy-db/google"
   version = "~> 2.0"
 
-  cluster_id       = "alloydb-v6-cluster"
-  cluster_location = var.region
+  cluster_id       = "cluster-1"
+  cluster_location = var.region1
   project_id       = var.project_id
 
   network_self_link           = "projects/${var.project_id}/global/networks/${var.network_name}"
-  cluster_encryption_key_name = google_kms_crypto_key.key.id
+  cluster_encryption_key_name = google_kms_crypto_key.key_region1.id
 
   automated_backup_policy = {
-    location      = var.region
+    location      = var.region1
     backup_window = "1800s"
     enabled       = true
     weekly_schedule = {
@@ -59,30 +38,29 @@ module "alloy-db" {
     labels = {
       test = "alloydb-cluster-with-prim"
     }
-    backup_encryption_key_name = google_kms_crypto_key.key.id
+    backup_encryption_key_name = google_kms_crypto_key.key_region1.id
   }
 
   continuous_backup_recovery_window_days = 10
-  continuous_backup_encryption_key_name  = google_kms_crypto_key.key.id
+  continuous_backup_encryption_key_name  = google_kms_crypto_key.key_region1.id
 
   primary_instance = {
-    instance_id        = "primary-instance-1",
+    instance_id        = "cluster-1-instance-1",
     require_connectors = false
     ssl_mode           = "ALLOW_UNENCRYPTED_AND_ENCRYPTED"
   }
 
   read_pool_instance = [
     {
-      instance_id        = "read-instance-1",
-      display_name       = "read-instance-1",
+      instance_id        = "cluster-1-rr-1"
+      display_name       = "cluster-1-rr-1"
       require_connectors = false
       ssl_mode           = "ALLOW_UNENCRYPTED_AND_ENCRYPTED"
+      # availability_type = "ZONAL"
     }
   ]
 
   depends_on = [
-    google_compute_network.default,
-    google_compute_global_address.private_ip_alloc,
     google_service_networking_connection.vpc_connection,
     google_kms_crypto_key_iam_member.alloydb_sa_iam,
   ]

--- a/examples/simple_example/network.tf
+++ b/examples/simple_example/network.tf
@@ -1,0 +1,38 @@
+/**
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+resource "google_compute_network" "default" {
+  name    = var.network_name
+  project = var.project_id
+}
+
+
+resource "google_compute_global_address" "private_ip_alloc" {
+  project       = var.project_id
+  name          = "adb-psa"
+  address_type  = "INTERNAL"
+  purpose       = "VPC_PEERING"
+  prefix_length = 12
+  network       = google_compute_network.default.id
+  address       = "172.16.0.0"
+}
+
+resource "google_service_networking_connection" "vpc_connection" {
+  network                 = google_compute_network.default.id
+  service                 = "servicenetworking.googleapis.com"
+  reserved_peering_ranges = [google_compute_global_address.private_ip_alloc.name]
+  deletion_policy         = "ABANDON"
+}

--- a/examples/simple_example/outputs.tf
+++ b/examples/simple_example/outputs.tf
@@ -14,16 +14,6 @@
  * limitations under the License.
  */
 
-output "cluster_id" {
-  description = "ID of the Alloy DB Cluster created"
-  value       = module.alloy-db.cluster_id
-}
-
-output "primary_instance_id" {
-  description = "ID of the primary instance created"
-  value       = module.alloy-db.primary_instance_id
-}
-
 output "project_id" {
   description = "Project ID of the Alloy DB Cluster created"
   value       = var.project_id
@@ -31,40 +21,50 @@ output "project_id" {
 
 output "kms_key_name" {
   description = "he fully-qualified resource name of the KMS key"
-  value       = google_kms_crypto_key.key.id
+  value       = google_kms_crypto_key.key_region1.id
+}
+
+output "cluster_id" {
+  description = "ID of the Alloy DB Cluster created"
+  value       = module.alloydb1.cluster_id
+}
+
+output "primary_instance_id" {
+  description = "ID of the primary instance created"
+  value       = module.alloydb1.primary_instance_id
 }
 
 output "cluster_name" {
   description = "The name of the cluster resource"
-  value       = module.alloy-db.cluster_name
+  value       = module.alloydb1.cluster_name
 }
 
 output "region" {
   description = "The region for primary cluster"
-  value       = var.region
+  value       = var.region1
 }
 
 output "secondary_region" {
   description = "The region for cross region replica secondary cluster"
-  value       = var.secondary_region
+  value       = var.region2
 }
 
 output "secondary_cluster_id" {
   description = "ID of the Secondary Alloy DB Cluster created"
-  value       = module.alloy-db-secondary.cluster_id
+  value       = module.alloydb2.cluster_id
 }
 
 output "secondary_primary_instance_id" {
   description = "ID of the Secondary Cluster primary instance created"
-  value       = module.alloy-db-secondary.primary_instance_id
+  value       = module.alloydb2.primary_instance_id
 }
 
 output "secondary_kms_key_name" {
   description = "he fully-qualified resource name of the Secondary clusterKMS key"
-  value       = google_kms_crypto_key.key_secondary.id
+  value       = google_kms_crypto_key.key_region2.id
 }
 
 output "secondary_cluster_name" {
   description = "The name of the Secondary cluster resource"
-  value       = module.alloy-db-secondary.cluster_name
+  value       = module.alloydb2.cluster_name
 }

--- a/examples/simple_example/outputs.tf
+++ b/examples/simple_example/outputs.tf
@@ -21,50 +21,50 @@ output "project_id" {
 
 output "kms_key_name" {
   description = "he fully-qualified resource name of the KMS key"
-  value       = google_kms_crypto_key.key_region1.id
+  value       = google_kms_crypto_key.key_region_central.id
 }
 
 output "cluster_id" {
   description = "ID of the Alloy DB Cluster created"
-  value       = module.alloydb1.cluster_id
+  value       = module.alloydb_central.cluster_id
 }
 
 output "primary_instance_id" {
   description = "ID of the primary instance created"
-  value       = module.alloydb1.primary_instance_id
+  value       = module.alloydb_central.primary_instance_id
 }
 
 output "cluster_name" {
   description = "The name of the cluster resource"
-  value       = module.alloydb1.cluster_name
+  value       = module.alloydb_central.cluster_name
 }
 
 output "region" {
   description = "The region for primary cluster"
-  value       = var.region1
+  value       = var.region_central
 }
 
 output "secondary_region" {
   description = "The region for cross region replica secondary cluster"
-  value       = var.region2
+  value       = var.region_east
 }
 
 output "secondary_cluster_id" {
   description = "ID of the Secondary Alloy DB Cluster created"
-  value       = module.alloydb2.cluster_id
+  value       = module.alloydb_east.cluster_id
 }
 
 output "secondary_primary_instance_id" {
   description = "ID of the Secondary Cluster primary instance created"
-  value       = module.alloydb2.primary_instance_id
+  value       = module.alloydb_east.primary_instance_id
 }
 
 output "secondary_kms_key_name" {
   description = "he fully-qualified resource name of the Secondary clusterKMS key"
-  value       = google_kms_crypto_key.key_region2.id
+  value       = google_kms_crypto_key.key_region_east.id
 }
 
 output "secondary_cluster_name" {
   description = "The name of the Secondary cluster resource"
-  value       = module.alloydb2.cluster_name
+  value       = module.alloydb_east.cluster_name
 }

--- a/examples/simple_example/variables.tf
+++ b/examples/simple_example/variables.tf
@@ -26,14 +26,14 @@ variable "network_name" {
 }
 
 
-variable "region1" {
+variable "region_central" {
   default     = "us-central1"
-  description = "The region for cluster 1"
+  description = "The region for cluster in central us"
   type        = string
 }
 
-variable "region2" {
+variable "region_east" {
   default     = "us-east1"
-  description = "The region for cluster 2"
+  description = "The region for cluster in east us"
   type        = string
 }

--- a/examples/simple_example/variables.tf
+++ b/examples/simple_example/variables.tf
@@ -22,18 +22,18 @@ variable "project_id" {
 variable "network_name" {
   description = "The ID of the network in which to provision resources."
   type        = string
-  default     = "simple"
+  default     = "simple-adb"
 }
 
 
-variable "region" {
+variable "region1" {
   default     = "us-central1"
-  description = "The region for primary cluster"
+  description = "The region for cluster 1"
   type        = string
 }
 
-variable "secondary_region" {
+variable "region2" {
   default     = "us-east1"
-  description = "The region for cross region replica secondary cluster"
+  description = "The region for cluster 2"
   type        = string
 }

--- a/main.tf
+++ b/main.tf
@@ -111,22 +111,6 @@ resource "google_alloydb_cluster" "default" {
 
   }
 
-  # # N/A for secondary cluster
-  # dynamic "continuous_backup_config" {
-  #   for_each = var.continuous_backup_enable && !local.is_secondary_cluster ? ["continuous_backup_config"] : []
-  #   content {
-  #     enabled              = var.continuous_backup_enable
-  #     recovery_window_days = var.continuous_backup_recovery_window_days
-  #     dynamic "encryption_config" {
-  #       for_each = var.continuous_backup_encryption_key_name == null ? [] : ["cont_backup_encryption_config"]
-  #       content {
-  #         kms_key_name = var.continuous_backup_encryption_key_name
-  #       }
-  #     }
-
-  #   }
-  # }
-
   dynamic "initial_user" {
     for_each = var.cluster_initial_user == null ? [] : ["cluster_initial_user"]
     content {

--- a/test/integration/simple_example/simple_example_test.go
+++ b/test/integration/simple_example/simple_example_test.go
@@ -39,9 +39,6 @@ func TestSimpleExample(t *testing.T) {
 		alloydbClusterIdPathList := strings.Split(example.GetStringOutput("cluster_id"), "/")
 		alloydbClusterId := alloydbClusterIdPathList[len(alloydbClusterIdPathList)-1]
 
-		// Primary Instance Information
-		alloydbPrimaryInstancePath := example.GetStringOutput("primary_instance_id")
-
 		cluster_location := region
 		state := "READY"
 		gcOpsClusterInfo := gcloud.WithCommonArgs([]string{"--project", projectId, "--region", cluster_location, "--format", "json"})
@@ -54,9 +51,6 @@ func TestSimpleExample(t *testing.T) {
 		secondaryAlloydbClusterIdPath := example.GetStringOutput("secondary_cluster_id")
 		secondaryAlloydbClusterIdPathList := strings.Split(example.GetStringOutput("secondary_cluster_id"), "/")
 		secondaryAlloydbClusterId := secondaryAlloydbClusterIdPathList[len(secondaryAlloydbClusterIdPathList)-1]
-
-		// Secondary Primary Instance Information
-		secondaryAlloydbPrimaryInstancePath := example.GetStringOutput("secondary_primary_instance_id")
 
 		secondary_cluster_location := secondaryRegion
 		secondaryGcOpsClusterInfo := gcloud.WithCommonArgs([]string{"--project", projectId, "--region", secondary_cluster_location, "--format", "json"})
@@ -76,17 +70,15 @@ func TestSimpleExample(t *testing.T) {
 		assert.Equal("PRIMARY", alloyDBClusterInfo.Get("clusterType").String(), "Cluster type match")
 
 		// Check for Primary Instance
-		assert.Equal(alloydbPrimaryInstancePath, alloyDBInstanceInfo.Get("name").String(), "Has to be same Primary Instance Path")
 		assert.Equal(state, alloyDBInstanceInfo.Get("state").String())
 
 		// check for Secondary Cluster
 		assert.Equal(secondaryAlloydbClusterIdPath, secondaryAlloyDBClusterInfo.Get("name").String(), "Has to be same secondary Cluster path")
-		assert.False(secondaryAlloyDBClusterInfo.Get("continuousBackupConfig.enabled").Bool(), "continuous Backup.enabled is set to False")
+		assert.True(secondaryAlloyDBClusterInfo.Get("continuousBackupConfig.enabled").Bool(), "continuous Backup.enabled is set to False")
 		assert.Equal(secondarykmsKeyName, secondaryAlloyDBClusterInfo.Get("encryptionConfig.kmsKeyName").String(), "Cluster Encryption key name match for secondary cluster")
 		assert.Equal("SECONDARY", secondaryAlloyDBClusterInfo.Get("clusterType").String(), "Cluster type match")
 
 		// Check for Secondary  Instance
-		assert.Equal(secondaryAlloydbPrimaryInstancePath, SecondaryAlloyDBInstanceInfo.Get("name").String(), "Has to be same Primary Instance Path for secondary cluster")
 		assert.Equal(state, SecondaryAlloyDBInstanceInfo.Get("state").String())
 
 	})

--- a/variables.tf
+++ b/variables.tf
@@ -26,10 +26,15 @@ variable "cluster_id" {
   }
 }
 
-variable "cluster_location" {
-  description = "Location where AlloyDb cluster will be deployed."
+variable "cluster_type" {
+  description = "The type of cluster. If not set, defaults to PRIMARY. Default value is PRIMARY. Possible values are: PRIMARY, SECONDARY"
   type        = string
-  # default     = "us-central1"
+  default     = "PRIMARY"
+}
+
+variable "cluster_location" {
+  description = "Location where AlloyDb cluster will be deployed"
+  type        = string
 }
 
 variable "cluster_labels" {

--- a/variables.tf
+++ b/variables.tf
@@ -118,7 +118,7 @@ variable "primary_instance" {
   })
   validation {
     condition     = can(regex("^(2|4|8|16|32|64|96|128)$", var.primary_instance.machine_cpu_count))
-    error_message = "cpu count must be one of [2 4 8 16 32 64 96 128]"
+    error_message = "machine_cpu_count must be one of [2, 4, 8, 16, 32, 64, 96, 128]"
   }
   validation {
     condition     = can(regex("^[a-z]([a-z0-9-]{0,61}[a-z0-9])?$", var.primary_instance.instance_id))
@@ -140,6 +140,10 @@ variable "read_pool_instance" {
     require_connectors = optional(bool),
   }))
   default = []
+  validation {
+    condition     = try(alltrue([for rp in var.read_pool_instance : contains(["2", "4", "8", "16", "32", "64", "96", "128"], tostring(rp.machine_cpu_count))]), false) || var.read_pool_instance == null
+    error_message = "machine_cpu_count must be one of [2, 4, 8, 16, 32, 64, 96, 128]"
+  }
 }
 
 variable "primary_cluster_name" {


### PR DESCRIPTION
fix #74 
Fixed error noticed in PR #71
Seems like API behavior changed. 

```
Error creating Cluster: googleapi: Error 400: The request was invalid: no automated backup policy was specified for secondary. Could not copy primary's configuration because an encryption key was present. Either explicitly disable the secondary's automated backup policy, or specify the policy with a CMEK.
```