### PR TITLE
Fix: Correct read pool PSC DNS name reference

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -51,7 +51,7 @@ output "read_psc_attachment_links" {
 output "read_psc_dns_names" {
   description = "The DNS names of the instances for PSC connectivity created for replica instances"
   value = try([
-    for rd, details in google_alloydb_instance.read_pool : details.psc_instance_config[0].service_attachment_link
+    for rd, details in google_alloydb_instance.read_pool : details.psc_instance_config[0].psc_dns_name
   ], "")
 }
 


### PR DESCRIPTION
Corrects the reference in the output configuration from service_attachment_link to psc_dns_name for the read pool instances output `read_psc_dns_names`

Changes:

Updated the output block to reference details.psc_instance_config[0].psc_dns_name instead of details.psc_instance_config[0].service_attachment_link.

Impact:

Ensures accurate DNS names are output for PSC connectivity of read pool instances.