### PR TITLE
fix: add set cluster output to sensitive

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -63,6 +63,7 @@ output "cluster_name" {
 output "cluster" {
   description = "Cluster created"
   value       = resource.google_alloydb_cluster.default
+  sensitive   = true
 }
 
 output "primary_instance" {


### PR DESCRIPTION
Mark the `cluster` output as sensitive, as this causes errors in e.g. terragrunt when setting the `cluster_initial_user`:
``` 
╷
│ Error: Output refers to sensitive values
│ 
│   on outputs.tf line 63:
│   63: output "cluster" {
│ 
│ To reduce the risk of accidentally exporting sensitive data that was
│ intended to be only internal, Terraform requires that any root module
│ output containing sensitive data be explicitly marked as sensitive, to
│ confirm your intent.
│ 
│ If you do intend to export this data, annotate the output value as
│ sensitive by adding the following argument:
│     sensitive = true
```