### PR TITLE
feat: Add missing VPC connection for Alloydb

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -48,7 +48,7 @@ resource "google_alloydb_cluster" "default" {
   dynamic "network_config" {
     for_each = var.network_self_link == null ? [] : ["network_config"]
     content {
-      network            = var.network_self_link
+      network            = replace(var.network_self_link, "https://www.googleapis.com/compute/v1/", "")
       allocated_ip_range = var.allocated_ip_range
     }
   }

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -136,6 +136,12 @@ spec:
       - name: network_self_link
         description: Network ID where the AlloyDb cluster will be deployed. If network_self_link is set then psc_enabled should be set to false. The resource link should point to a VPC network in the same project as the cluster, where the cluster resources are created and accessed via Private IP. Any network used, including the default network (if none is specified), must have VPC peering enabled. Learn more at https://cloud.google.com/alloydb/docs/configure-connectivity
         varType: string
+        connections:
+        - source:
+            source: github.com/terraform-google-modules/terraform-google-network
+            version: ">= v18.1.0"
+          spec:
+            outputExpr: network_self_link
       - name: primary_instance
         description: Configure primary instance. Every AlloyDB cluster has one primary instance, providing a read or write access point to your data. See https://cloud.google.com/alloydb/docs/reference/rest/v1/projects.locations.clusters.instances for more details.
         varType: |-


### PR DESCRIPTION
Adding missing VPC connection for Alloydb component.

Testing Steps for VPC Connection:

Used the Automation script for implementing missing connections in ADC to perform the below steps:

1) Ingest Component Revision (BYOC):
a) Set the gcloud configuration to point to the Staging environment.
b) Create the template metadata for the Alloydb component.
c) Create a template revision to pull our specific code tag (v8.2.0) into the private catalog.

2) Adding components and connections and filling up param values:
a) In the ADC canvas, add the custom Alloydb and VPC components.
b) Add a connection line between the two.
c) Fill all required configuration parameters for all 2 components (e.g., region, project, name, etc)

3) App Deployment:
a) Create a new application with the connected components.
b) Deploy and ensure the application deployment completes successfully.
c) Iterate in case of failures, trying with different values.

Alloydb metadata schema validation successfully done:
https://paste.googleplex.com/6674142832230400

Successful testing in Staging environment:
App deployment: https://screenshot.googleplex.com/AGQfK3LomnB9aMh
Connection Params: https://screenshot.googleplex.com/ARSzvLaGdfcg67o