### PR TITLE
fix: ignore restore_continuous_backup_source changes to prevent ForceNew after cluster creation

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -185,6 +185,10 @@ resource "google_alloydb_cluster" "default" {
     }
   }
 
+  lifecycle {
+    ignore_changes = [restore_continuous_backup_source, restore_backup_source]
+  }
+
 }
 
 


### PR DESCRIPTION
**Problem:** After an AlloyDB cluster is created via PITR restore, setting `restore_cluster = null `(e.g. to remove dependency on the source cluster) triggers a `ForceNew` because `restore_continuous_backup_source` is marked `ForceNew: true` in the provider schema. This destroys and recreates the live cluster.

**Fix:** Add `lifecycle { ignore_changes = [restore_continuous_backup_source, restore_backup_source] } `to `google_alloydb_cluster.default`. The restore blocks are write-once at creation time — subsequent plans should not diff on them.

**Ref:** https://github.com/hashicorp/terraform-provider-google/issues/13601

Issue:- https://github.com/GoogleCloudPlatform/terraform-google-alloy-db/issues/193