### PR TITLE
fix(alloydb): add gce_zone to lifecycle ignore_changes for primary in…

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -271,7 +271,7 @@ resource "google_alloydb_instance" "primary" {
   }
 
   lifecycle {
-    ignore_changes = [instance_type]
+    ignore_changes = [instance_type, gce_zone]
   }
 }
 


### PR DESCRIPTION
Fix permadiff on gce_zone for ZONAL primary instances
The Google AlloyDB API does not return gce_zone in GET responses for any instance type ([https://github.com/hashicorp/terraform-provider-google/issues/13378](https://github.com/hashicorp/terraform-provider-google/issues/13378)). This causes a permanent diff on every terraform plan when gce_zone is set in config.
This adds gce_zone to the lifecycle { ignore_changes } block for the primary instance resource, matching the existing pattern for instance_type.
Note: availability_type is intentionally NOT added — the API now returns this field for primary instances (confirmed Nov 2023).